### PR TITLE
Set values to be null instead false

### DIFF
--- a/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
+++ b/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
@@ -256,7 +256,9 @@ class AuditSubscriber implements EventSubscriber
             } else {
                 $typ = Type::getType(Type::BIGINT); // relation
             }
-
+            if (in_array($name, ['source', 'target', 'blame']) && $data[$name] === false) {
+                $data[$name] = null;
+            }
             $this->auditInsertStmt->bindValue($idx++, $data[$name], $typ);
         }
         $this->auditInsertStmt->execute();


### PR DESCRIPTION
If PostgreSQL is being used instead of MySQL, errors are being thrown:

`Invalid text representation: 7 ERROR:  invalid input syntax for integer: ""`

So far, I've used this dirty workaround to set empty values to be null, but maybe there is a better way to handle this.