### PR TITLE
Workaround for current Doctrines protected getInsertSQL()

### DIFF
--- a/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
+++ b/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
@@ -111,9 +111,13 @@ class AuditSubscriber implements EventSubscriber
         $uow = $em->getUnitOfWork();
 
         $auditPersister = $uow->getEntityPersister(AuditLog::class);
-        $this->auditInsertStmt = $em->getConnection()->prepare($auditPersister->getInsertSql());
+        $rmAuditInsertSQL = new \ReflectionMethod($auditPersister, 'getInsertSQL');
+        $rmAuditInsertSQL->setAccessible(true);
+        $this->auditInsertStmt = $em->getConnection()->prepare($rmAuditInsertSQL->invoke($auditPersister));
         $assocPersister = $uow->getEntityPersister(Association::class);
-        $this->assocInsertStmt = $em->getConnection()->prepare($assocPersister->getInsertSql());
+        $rmAssocInsertSQL = new \ReflectionMethod($assocPersister, 'getInsertSQL');
+        $rmAssocInsertSQL->setAccessible(true);
+        $this->assocInsertStmt = $em->getConnection()->prepare($rmAssocInsertSQL->invoke($assocPersister));
 
         foreach ($this->updated as $entry) {
             list($entity, $ch) = $entry;


### PR DESCRIPTION
Current Doctrine versions have made BasicEntityPersister::getInsertSQL() protected, which breaks AuditSubscriber. Preferrably, AuditSubscriber should be rewritten to use the public API of BasicEntityPersister, however on first glance this appears non-trivial, at least until [Doctrine issue #4767](https://github.com/doctrine/doctrine2/issues/4767) gets resolved.
In the meantime, this provides a workaround using ReflectionMethod() to access getInsertSQL() anyway.