### PR TITLE
clarify install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ First, install it with composer:
 
 Then, add it in your **AppKernel** bundles.
 
+    // app/AppKernel.php
+    public function registerBundles()
+    {
+        $bundles = array(
+            ...
+            new DataDog\AuditBundle\DataDogAuditBundle(),
+            ...
+        );
+        ...
+    }
+
 ## Demo
 
 The best way to see features is to see the actual demo. Just clone the bundle


### PR DESCRIPTION
Added a copy/paste-able example of the AppKernel bundle entry that needs to be made.