### PR TITLE
Option to disable audit for some entities, custom labeler fix/extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ symfony application.
 **audit** entities will be mapped automatically if you run schema update or similar.
 And all the database changes will be reflected in the audit log afterwards.
 
+### Unaudited Entities
+
+Sometimes, you might not want to create audit log entries for particular entities.
+You can achieve this by listing those entities under the `unaudired_entities` configuuration
+key in your `config.yml`, for example:
+
+    data_dog_audit:
+        unaudited_entities:
+            - AppBundle\Entity\NoAuditForThis
+
 ## Screenshots
 
 All paginated audit log:

--- a/src/DataDog/AuditBundle/DependencyInjection/Configuration.php
+++ b/src/DataDog/AuditBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace DataDog\AuditBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * Configuration for DataDog/AuditBundle
+ */
+class Configuration implements ConfigurationInterface
+{
+
+    /**
+     * {@inheritDoc}
+     * @see \Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('data_dog_audit');
+
+        $rootNode
+            ->children()
+                ->arrayNode('unaudited_entities')
+                    ->canBeUnset()
+                    ->performNoDeepMerging()
+                    ->prototype('scalar')->end()
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+
+}

--- a/src/DataDog/AuditBundle/DependencyInjection/DataDogAuditExtension.php
+++ b/src/DataDog/AuditBundle/DependencyInjection/DataDogAuditExtension.php
@@ -14,7 +14,15 @@ class DataDogAuditExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+
+        if (isset($config['unaudited_entities'])) {
+            $auditSubscriber = $container->getDefinition('datadog.event_subscriber.audit');
+            $auditSubscriber->addMethodCall('addUnauditedEntities', array($config['unaudited_entities']));
+        }
     }
 }

--- a/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
+++ b/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
@@ -335,7 +335,7 @@ class AuditSubscriber implements EventSubscriber
     private function label(EntityManager $em, $entity)
     {
         if (is_callable($this->labeler)) {
-            return $this->labeler($entity);
+            return call_user_func($this->labeler, $entity);
         }
         $meta = $em->getClassMetadata(get_class($entity));
         switch (true) {

--- a/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
+++ b/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
@@ -31,6 +31,8 @@ class AuditSubscriber implements EventSubscriber
      */
     protected $securityTokenStorage;
 
+    private $unauditedEntities = [];
+
     private $inserted = []; // [$source, $changeset]
     private $updated = []; // [$source, $changeset]
     private $removed = []; // [$source, $id]
@@ -56,6 +58,24 @@ class AuditSubscriber implements EventSubscriber
         return $this->labeler;
     }
 
+    public function addUnauditedEntities(array $unauditedEntities)
+    {
+        // use entity names as array keys for easier lookup
+        foreach ($unauditedEntities as $unauditedEntity) {
+            $this->unauditedEntities[$unauditedEntity] = true;
+        }
+    }
+
+    public function getUnauditedEntities()
+    {
+        return array_keys($this->unauditedEntities);
+    }
+
+    private function isEntityUnaudited($entity)
+    {
+        return isset($this->unauditedEntities[get_class($entity)]);
+    }
+
     public function onFlush(OnFlushEventArgs $args)
     {
         $em = $args->getEntityManager();
@@ -73,33 +93,57 @@ class AuditSubscriber implements EventSubscriber
         $em->getConnection()->getConfiguration()->setSQLLogger($new);
 
         foreach ($uow->getScheduledEntityUpdates() as $entity) {
+            if ($this->isEntityUnaudited($entity)) {
+                continue;
+            }
             $this->updated[] = [$entity, $uow->getEntityChangeSet($entity)];
         }
         foreach ($uow->getScheduledEntityInsertions() as $entity) {
+            if ($this->isEntityUnaudited($entity)) {
+                continue;
+            }
             $this->inserted[] = [$entity, $ch = $uow->getEntityChangeSet($entity)];
         }
         foreach ($uow->getScheduledEntityDeletions() as $entity) {
+            if ($this->isEntityUnaudited($entity)) {
+                continue;
+            }
             $uow->initializeObject($entity);
             $this->removed[] = [$entity, $this->id($em, $entity)];
         }
         foreach ($uow->getScheduledCollectionUpdates() as $collection) {
+            if ($this->isEntityUnaudited($collection->getOwner())) {
+                continue;
+            }
             $mapping = $collection->getMapping();
             if (!$mapping['isOwningSide'] || $mapping['type'] !== ClassMetadataInfo::MANY_TO_MANY) {
                 continue; // ignore inverse side or one to many relations
             }
             foreach ($collection->getInsertDiff() as $entity) {
+                if ($this->isEntityUnaudited($entity)) {
+                    continue;
+                }
                 $this->associated[] = [$collection->getOwner(), $entity, $mapping];
             }
             foreach ($collection->getDeleteDiff() as $entity) {
+                if ($this->isEntityUnaudited($entity)) {
+                    continue;
+                }
                 $this->dissociated[] = [$collection->getOwner(), $entity, $this->id($em, $entity), $mapping];
             }
         }
         foreach ($uow->getScheduledCollectionDeletions() as $collection) {
+            if ($this->isEntityUnaudited($collection->getOwner())) {
+                continue;
+            }
             $mapping = $collection->getMapping();
             if (!$mapping['isOwningSide'] || $mapping['type'] !== ClassMetadataInfo::MANY_TO_MANY) {
                 continue; // ignore inverse side or one to many relations
             }
             foreach ($collection->toArray() as $entity) {
+                if ($this->isEntityUnaudited($entity)) {
+                    continue;
+                }
                 $this->dissociated[] = [$collection->getOwner(), $entity, $this->id($em, $entity), $mapping];
             }
         }


### PR DESCRIPTION
This pull request contains two things:

- add configuration options to disable audit logging for some entities, with documentation in README.md
- use call_user_func() to call the custom labeler, which for example permits using object methods as a custom labeler
