### PR TITLE
Change Association table field type

### DIFF
--- a/src/DataDog/AuditBundle/Entity/Association.php
+++ b/src/DataDog/AuditBundle/Entity/Association.php
@@ -28,7 +28,7 @@ class Association
     private $tbl;
 
     /**
-     * @ORM\Column(nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      */
     private $label;
 

--- a/src/DataDog/AuditBundle/Resources/config/doctrine/Association.orm.xml
+++ b/src/DataDog/AuditBundle/Resources/config/doctrine/Association.orm.xml
@@ -11,7 +11,7 @@
 
     <field name="typ" length="128" />
     <field name="tbl" length="128" />
-    <field name="label" nullable="true" />
+    <field name="label" type="text" nullable="true" />
     <field name="fk" />
     <field name="class" />
 

--- a/src/DataDog/AuditBundle/Resources/config/doctrine/Association.orm.yml
+++ b/src/DataDog/AuditBundle/Resources/config/doctrine/Association.orm.yml
@@ -14,6 +14,7 @@ DataDog\AuditBundle\Entity\Association:
       length: 128
     label:
       nullable: true
+      type: text
     fk:
       type: string
     class:


### PR DESCRIPTION
Field "label" type in table "audit_associations" changed to TEXT instead of VARCHAR(255), because in some cases with very long labels text is truncated and an error is generated.