### PR TITLE
Add ability to set the blame user

### DIFF
--- a/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
+++ b/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
@@ -42,6 +42,9 @@ class AuditSubscriber implements EventSubscriber
     private $assocInsertStmt;
     private $auditInsertStmt;
 
+    /** @var UserInterface */
+    private $blameUser;
+
     public function __construct(TokenStorage $securityTokenStorage)
     {
         $this->securityTokenStorage = $securityTokenStorage;
@@ -409,6 +412,9 @@ class AuditSubscriber implements EventSubscriber
 
     protected function blame(EntityManager $em)
     {
+        if ($this->blameUser instanceof UserInterface) {
+            return $this->assoc($em, $this->blameUser);
+        }
         $token = $this->securityTokenStorage->getToken();
         if ($token && $token->getUser() instanceof UserInterface) {
             return $this->assoc($em, $token->getUser());
@@ -419,5 +425,10 @@ class AuditSubscriber implements EventSubscriber
     public function getSubscribedEvents()
     {
         return [Events::onFlush];
+    }
+
+    public function setBlameUser(UserInterface $user)
+    {
+        $this->blameUser = $user;
     }
 }


### PR DESCRIPTION
Resolves: #17

With the ability to easily set the blame user, this allows background processes and Symfony commands to make changes on a user's behalf and not break the audit history by having `null` for the blamed user.