### PR TITLE
- possibility to define audited entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,22 @@ And all the database changes will be reflected in the audit log afterwards.
 ### Unaudited Entities
 
 Sometimes, you might not want to create audit log entries for particular entities.
-You can achieve this by listing those entities under the `unaudired_entities` configuuration
+You can achieve this by listing those entities under the `unaudited_entities` configuration
 key in your `config.yml`, for example:
 
     data_dog_audit:
         unaudited_entities:
             - AppBundle\Entity\NoAuditForThis
+
+### Specify Audited Entities 
+
+Sometimes, it is also possible, that you want to create audit log entries only for particular entities. You can achieve it quite similar to unaudited entities. You can list them under the `audited_entities` configuration key in your `config.yml`, for example:
+
+    data_dog_audit:
+        audited_entities:
+            - AppBundle\Entity\AuditForThis
+
+You can specify either audited or unaudited entities. If both are specified, only audited entities would be taken into account.
 
 ## Screenshots
 

--- a/src/DataDog/AuditBundle/DependencyInjection/Configuration.php
+++ b/src/DataDog/AuditBundle/DependencyInjection/Configuration.php
@@ -22,6 +22,16 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->arrayNode('audited_entities')
+                    ->canBeUnset()
+                    ->performNoDeepMerging()
+                    ->prototype('scalar')->end()
+                ->end()
+            ->end()
+        ;
+
+        $rootNode
+            ->children()
                 ->arrayNode('unaudited_entities')
                     ->canBeUnset()
                     ->performNoDeepMerging()

--- a/src/DataDog/AuditBundle/DependencyInjection/DataDogAuditExtension.php
+++ b/src/DataDog/AuditBundle/DependencyInjection/DataDogAuditExtension.php
@@ -20,8 +20,11 @@ class DataDogAuditExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 
-        if (isset($config['unaudited_entities'])) {
-            $auditSubscriber = $container->getDefinition('datadog.event_subscriber.audit');
+        $auditSubscriber = $container->getDefinition('datadog.event_subscriber.audit');
+
+        if (isset($config['audited_entities'])) {
+            $auditSubscriber->addMethodCall('addAuditedEntities', array($config['audited_entities']));
+        } else if (isset($config['unaudited_entities'])) {
             $auditSubscriber->addMethodCall('addUnauditedEntities', array($config['unaudited_entities']));
         }
     }

--- a/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
+++ b/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
@@ -31,6 +31,7 @@ class AuditSubscriber implements EventSubscriber
      */
     protected $securityTokenStorage;
 
+    private $auditedEntities = [];
     private $unauditedEntities = [];
 
     private $inserted = []; // [$source, $changeset]
@@ -61,6 +62,14 @@ class AuditSubscriber implements EventSubscriber
         return $this->labeler;
     }
 
+    public function addAuditedEntities(array $auditedEntities)
+    {
+        // use entity names as array keys for easier lookup
+        foreach ($auditedEntities as $auditedEntity) {
+            $this->auditedEntities[$auditedEntity] = true;
+        }
+    }
+
     public function addUnauditedEntities(array $unauditedEntities)
     {
         // use entity names as array keys for easier lookup
@@ -76,7 +85,14 @@ class AuditSubscriber implements EventSubscriber
 
     private function isEntityUnaudited($entity)
     {
-        return isset($this->unauditedEntities[get_class($entity)]);
+        if (!empty($this->auditedEntities)) {
+            // only selected entities are audited
+            $isEntityUnaudited = !isset($this->auditedEntities[get_class($entity)]);
+        } else {
+            $isEntityUnaudited = isset($this->unauditedEntities[get_class($entity)]);
+        }
+
+        return $isEntityUnaudited;
     }
 
     public function onFlush(OnFlushEventArgs $args)


### PR DESCRIPTION
Hello,
  I added possibility to declare only those entities, which we want to log. I combined it with unaudited functionality (only unaudited or audited can be declared - if both are declared, only audited are used).  In yml configuration we use similar configuration like for unaudited:

data_dog_audit:
        audited_entities:
            - AppBundle\Entity\AuditedEntity
