### PR TITLE
Added dependency for Symfony Security Component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
   "require": {
     "php": ">=5.4.0",
     "symfony/framework-bundle": "^2.6|^3.0|^4.0",
+    "symfony/security": "^4.0",
     "doctrine/orm": "^2.4"
   },
 


### PR DESCRIPTION
File composer.json lacks of a dependency to Symfony Security Component, but the component is used in [AuditSubscriber](https://github.com/DATA-DOG/DataDogAuditBundle/blob/fa1f88b97d023a2148bc628923ffd08e4b6e5da3/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php#L9).