### PR TITLE
Added support to non-Doctrine entities

### DIFF
--- a/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
+++ b/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
@@ -389,11 +389,20 @@ class AuditSubscriber implements EventSubscriber
         if (null === $association) {
             return null;
         }
-        $meta = $em->getClassMetadata(get_class($association));
-        $res = ['class' => $meta->name, 'typ' => $this->typ($meta->name), 'tbl' => $meta->table['name']];
-        $em->getUnitOfWork()->initializeObject($association); // ensure that proxies are initialized
-        $res['fk'] = (string)$this->id($em, $association);
-        $res['label'] = $this->label($em, $association);
+
+        $meta = get_class($association);
+        $res = ['class' => $meta, 'typ' => $this->typ($meta), 'tbl' => null, 'label' => null];
+
+        try {
+            $meta = $em->getClassMetadata($meta);
+            $res['tbl'] = $meta->table['name'];
+            $em->getUnitOfWork()->initializeObject($association); // ensure that proxies are initialized
+            $res['fk'] = (string)$this->id($em, $association);
+            $res['label'] = $this->label($em, $association);
+        } catch (\Exception $e) {
+            $res['fk'] = (string) $association->getId();
+        }
+
         return $res;
     }
 

--- a/src/DataDog/AuditBundle/Resources/config/doctrine/Association.orm.xml
+++ b/src/DataDog/AuditBundle/Resources/config/doctrine/Association.orm.xml
@@ -10,7 +10,7 @@
     </id>
 
     <field name="typ" length="128" />
-    <field name="tbl" length="128" />
+    <field name="tbl" length="128" nullable="true" />
     <field name="label" nullable="true" />
     <field name="fk" />
     <field name="class" />

--- a/src/DataDog/AuditBundle/Resources/config/doctrine/Association.orm.yml
+++ b/src/DataDog/AuditBundle/Resources/config/doctrine/Association.orm.yml
@@ -12,6 +12,7 @@ DataDog\AuditBundle\Entity\Association:
       length: 128
     tbl:
       length: 128
+      nullable: true
     label:
       nullable: true
     fk:


### PR DESCRIPTION
If the ```userInterface``` is not a Doctrine entity, it will throw an exception when trying to call ```getClassMetadata``` inside ```EntityManager```.
This will happen when you have an user that doesn't not belong to your microservice - it only is a refer to an external service user.