### PR TITLE
json_encode the diff (doctrine/dbal 2.6 BC break)

### DIFF
--- a/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
+++ b/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
@@ -381,7 +381,7 @@ class AuditSubscriber implements EventSubscriber
                 ];
             }
         }
-        return $diff;
+        return json_encode($diff);
     }
 
     protected function assoc(EntityManager $em, $association = null)


### PR DESCRIPTION
When upgrading from Doctrine/DBAL: 2.5 to 2.6 the following error occurred :

![screenshot from 2018-12-04 16-08-10](https://user-images.githubusercontent.com/155956/49425251-570ced00-f7e0-11e8-8145-608f6b4c16ff.png)

In the 2.6 release, some changes were made regarding the json_array type. JSON encoding the diff value fixes the above error.