### PR TITLE
Doctrine Proxy Class Metadata

### DIFF
--- a/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
+++ b/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
@@ -404,7 +404,7 @@ class AuditSubscriber implements EventSubscriber
             return null;
         }
 
-        $meta = get_class($association);
+        $meta = $em->getClassMetadata(get_class($association))->getName();
         $res = ['class' => $meta, 'typ' => $this->typ($meta), 'tbl' => null, 'label' => null];
 
         try {


### PR DESCRIPTION
Use class metadata to get the entity class instead of the proxy class.
Fixes #68