### PR TITLE
-`json_encode` will error on resource variable values

### DIFF
--- a/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
+++ b/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
@@ -452,6 +452,16 @@ class AuditSubscriber implements EventSubscriber
 
     protected function value(EntityManager $em, Type $type, $value)
     {
+        // json_encode will error when trying to encode a resource
+        if (is_resource($value)) {
+            // https://stackoverflow.com/questions/26303513/getting-blob-type-doctrine-entity-property-returns-data-only-once/26306571
+            if (0 !== ftell($value)) {
+                rewind($value);
+            }
+
+            $value = stream_get_contents($value);
+        }
+
         $platform = $em->getConnection()->getDatabasePlatform();
         switch ($type->getName()) {
         case Type::BOOLEAN:


### PR DESCRIPTION
`json_encode` will error on resource values; doctrine treats blob columns as resource streams; when getting the old/new values from the diff, check for resource variable, rewind if necessary and get the stream contents. 