### PR TITLE
Add support for composite primary keys

### DIFF
--- a/src/DataDog/AuditBundle/DependencyInjection/Configuration.php
+++ b/src/DataDog/AuditBundle/DependencyInjection/Configuration.php
@@ -48,6 +48,14 @@ class Configuration implements ConfigurationInterface
             ->end()
         ;
 
+        $rootNode
+            ->children()
+                ->booleanNode('composite_keys')
+                    ->defaultFalse()
+                    ->info('Store association foreign keys as an associative array allowing composite keys.')
+            ->end()
+        ;
+
         return $treeBuilder;
     }
 

--- a/src/DataDog/AuditBundle/DependencyInjection/DataDogAuditExtension.php
+++ b/src/DataDog/AuditBundle/DependencyInjection/DataDogAuditExtension.php
@@ -31,5 +31,9 @@ class DataDogAuditExtension extends Extension
         if (isset($config['blame_impersonator'])) {
             $auditSubscriber->addMethodCall('setBlameImpersonator', array($config['blame_impersonator']));
         }
+        
+        if (isset($config['composite_keys'])) {
+            $auditSubscriber->addMethodCall('setCompositeKeys', array($config['composite_keys']));
+        }
     }
 }


### PR DESCRIPTION
I'm using composite primary keys for versioned entities so I added support for that. Because it changes the way foreign keys are stored I made a config option to activate it.