### PR TITLE
Resolves error due to TokenInterface with BC in Symfony 5

### DIFF
--- a/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
+++ b/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
@@ -495,12 +495,26 @@ class AuditSubscriber implements EventSubscriber
         if(!$token instanceof TokenInterface) {
             return null;
         }
-        foreach ($token->getRoles() as $role) {
+
+        foreach ($this->getRoles($token) as $role) {
             if ($role instanceof SwitchUserRole) {
                 return $role->getSource()->getUser();
             }
         }
         return null;
+    }
+
+    /**
+     * @param TokenInterface $token
+     * @return array
+     */
+    private function getRoles(TokenInterface $token)
+    {
+        if(method_exists($token, 'getRoleNames')){
+            return $token->getRoleNames();
+        }
+
+        return $token->getRoles();
     }
 
     public function getSubscribedEvents()


### PR DESCRIPTION
Resolves BC due to TokenInterface::getRoles changed to TokenInterface::getRoleNames on Symfony 5.