### PR TITLE
Add a doctrine/dbal constraint as the bundle is not compatible with v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
   "require": {
     "php": ">=5.4.0",
     "symfony/framework-bundle": "^2.6|^3.0|^4.0|^5.0",
-    "doctrine/orm": "^2.4"
+    "doctrine/dbal": "^2.5",
+    "doctrine/orm": "^2.5"
   },
 
   "require-dev": {
@@ -29,7 +30,6 @@
     "ext-pdo_sqlite": "*",
 
     "symfony/symfony": "^3.0|^4.0|^5.0",
-    "doctrine/orm": "^2.5",
     "doctrine/doctrine-bundle": "^1.6",
     "doctrine/doctrine-fixtures-bundle": "^2.2",
     "sensio/framework-extra-bundle": "^3.0.2",


### PR DESCRIPTION
More recently `doctrine/orm` v2 has been made to be compatible with `doctrine/dbal` v3. This bundle is not yet compatible with `doctrine/dbal` v3, so until then a constraint should be in place.

Ref: https://github.com/doctrine/orm/commit/c65cc91f5bf47087e58832587113b2327878d647