### PR TITLE
Updated LoggerChain usage. Support for dbal v3

### DIFF
--- a/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
+++ b/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
@@ -124,13 +124,15 @@ class AuditSubscriber implements EventSubscriber
 
         // extend the sql logger
         $this->old = $em->getConnection()->getConfiguration()->getSQLLogger();
-        $new = new LoggerChain();
-        $new->addLogger(new AuditLogger(function () use($em) {
-            $this->flush($em);
-        }));
+        $loggers = [
+            new AuditLogger(function () use($em) {
+                $this->flush($em);
+            }),
+        ];
         if ($this->old instanceof SQLLogger) {
-            $new->addLogger($this->old);
+            $loggers[] = $this->old;
         }
+        $new = new LoggerChain($loggers);
         $em->getConnection()->getConfiguration()->setSQLLogger($new);
 
         foreach ($uow->getScheduledEntityUpdates() as $entity) {


### PR DESCRIPTION
LoggerChain::addLogger method is deprecated in dbal v2 and removed in v3.
Loggers must be set via constructor instead.

https://github.com/doctrine/dbal/pull/3572