### PR TITLE
WIP: Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,32 +3,28 @@
   "type": "symfony-bundle",
   "description": "Audit bundle for symfony2 and doctrine orm, logs any database change",
   "keywords": ["audit", "log", "symfony2", "bundle", "doctrine", "orm"],
-  "homepage": "http://github.com/DATA-DOG/DataDogAuditBundle",
+  "homepage": "https://github.com/DATA-DOG/DataDogAuditBundle",
   "license": "MIT",
-
   "authors": [
     {
       "name": "DataDog Team",
-      "homepage": "http://datadog.lt"
+      "homepage": "https://datadog.lt"
     },
     {
       "name": "Symfony2 Community",
-      "homepage": "http://github.com/DATA-DOG/DataDogAuditBundle/contributors"
+      "homepage": "https://github.com/DATA-DOG/DataDogAuditBundle/contributors"
     }
   ],
-
   "require": {
     "php": ">=5.4.0",
     "symfony/framework-bundle": "^2.6|^3.0|^4.0|^5.0",
     "doctrine/dbal": "^2.5",
     "doctrine/orm": "^2.5"
   },
-
   "require-dev": {
     "php": ">=5.6.0",
     "ext-pdo": "*",
     "ext-pdo_sqlite": "*",
-
     "symfony/symfony": "^3.0|^4.0|^5.0",
     "doctrine/doctrine-bundle": "^1.6",
     "doctrine/doctrine-fixtures-bundle": "^2.2",
@@ -36,26 +32,21 @@
     "knplabs/knp-menu-bundle": "^2.0",
     "knplabs/knp-time-bundle": "^1.3",
     "data-dog/pager-bundle": "^0.2",
-
     "phpunit/phpunit": "~4.7.0"
   },
-
   "autoload": {
     "psr-4": {
       "DataDog\\AuditBundle\\": "src/DataDog/AuditBundle"
     }
   },
-
   "autoload-dev": {
     "psr-4": {
       "": "example/src/"
     }
   },
-
   "archive": {
     "exclude": ["vendor", "tests", "*phpunit.xml", ".travis.yml", "example", "Makefile", "screenshots"]
   },
-
   "extra": {
     "branch-alias": {
       "dev-master": "0.1.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -16,23 +16,21 @@
     }
   ],
   "require": {
-    "php": ">=5.4.0",
-    "symfony/framework-bundle": "^2.6|^3.0|^4.0|^5.0",
-    "doctrine/dbal": "^2.5",
-    "doctrine/orm": "^2.5"
+    "php": ">=7.4",
+    "doctrine/dbal": "^3.1.4",
+    "doctrine/orm": "^2.6",
+    "symfony/framework-bundle": "^4.4|^5.4|^6.0"
   },
   "require-dev": {
-    "php": ">=5.6.0",
     "ext-pdo": "*",
     "ext-pdo_sqlite": "*",
-    "symfony/symfony": "^3.0|^4.0|^5.0",
-    "doctrine/doctrine-bundle": "^1.6",
-    "doctrine/doctrine-fixtures-bundle": "^2.2",
-    "sensio/framework-extra-bundle": "^3.0.2",
+    "data-dog/pager-bundle": "^0.2",
+    "doctrine/doctrine-bundle": "^2.5",
+    "doctrine/doctrine-fixtures-bundle": "^3.4",
     "knplabs/knp-menu-bundle": "^2.0",
     "knplabs/knp-time-bundle": "^1.3",
-    "data-dog/pager-bundle": "^0.2",
-    "phpunit/phpunit": "~4.7.0"
+    "sensio/framework-extra-bundle": "^5.6",
+    "symfony/symfony": "^4.4|^5.4|^6.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
   "require": {
     "php": ">=5.4.0",
     "symfony/framework-bundle": "^2.6|^3.0|^4.0|^5.0",
-    "doctrine/orm": "^2.4"
+    "doctrine/dbal": "^2.5",
+    "doctrine/orm": "^2.5"
   },
 
   "require-dev": {
@@ -29,7 +30,6 @@
     "ext-pdo_sqlite": "*",
 
     "symfony/symfony": "^3.0|^4.0|^5.0",
-    "doctrine/orm": "^2.5",
     "doctrine/doctrine-bundle": "^1.6",
     "doctrine/doctrine-fixtures-bundle": "^2.2",
     "sensio/framework-extra-bundle": "^3.0.2",

--- a/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
+++ b/src/DataDog/AuditBundle/EventSubscriber/AuditSubscriber.php
@@ -11,6 +11,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Role\SwitchUserRole;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\DBAL\Logging\LoggerChain;
 use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\Common\EventSubscriber;
@@ -122,15 +123,20 @@ class AuditSubscriber implements EventSubscriber
         $em = $args->getEntityManager();
         $uow = $em->getUnitOfWork();
 
+        $loggers = [
+            new AuditLogger(function () use($em) {
+                $this->flush($em);
+            })
+        ];
+
         // extend the sql logger
         $this->old = $em->getConnection()->getConfiguration()->getSQLLogger();
-        $new = new LoggerChain();
-        $new->addLogger(new AuditLogger(function () use($em) {
-            $this->flush($em);
-        }));
+
         if ($this->old instanceof SQLLogger) {
-            $new->addLogger($this->old);
+            $loggers[] = $this->old;
         }
+
+        $new = new LoggerChain($loggers);
         $em->getConnection()->getConfiguration()->setSQLLogger($new);
 
         foreach ($uow->getScheduledEntityUpdates() as $entity) {
@@ -348,7 +354,7 @@ class AuditSubscriber implements EventSubscriber
             if (isset($meta->fieldMappings[$name]['type'])) {
                 $typ = $meta->fieldMappings[$name]['type'];
             } else {
-                $typ = Type::getType(Type::BIGINT); // relation
+                $typ = Type::getType(Types::BIGINT); // relation
             }
             // @TODO: this check may not be necessary, simply it ensures that empty values are nulled
             if (in_array($name, ['source', 'target', 'blame']) && $data[$name] === false) {
@@ -464,7 +470,7 @@ class AuditSubscriber implements EventSubscriber
 
         $platform = $em->getConnection()->getDatabasePlatform();
         switch ($type->getName()) {
-        case Type::BOOLEAN:
+        case Types::BOOLEAN:
             return $type->convertToPHPValue($value, $platform); // json supports boolean values
         default:
             return $type->convertToDatabaseValue($value, $platform);


### PR DESCRIPTION
Adds Symfony 6 support (closes #82) and drops support for outdated lib versions.

Notes:
- Removed phpunit as I don't see it being used
- Updated dev deps needed for the example site, but there's no instructions for setting this up, should be replaced by testing
- There looks to be some functionality that was removed with Symfony 5.0 that should be restored