### PR TITLE
feat(update): add new condition for doctrine mapping result on auditListener

### DIFF
--- a/src/EventListener/AuditListener.php
+++ b/src/EventListener/AuditListener.php
@@ -176,6 +176,9 @@ class AuditListener
                 continue;
             }
             $mapping = $collection->getMapping();
+            if (!is_array($mapping)) {
+                $mapping = $mapping->toArray();
+            }
             if (!$mapping['isOwningSide'] || $mapping['type'] !== ClassMetadata::MANY_TO_MANY) {
                 continue; // ignore inverse side or one to many relations
             }


### PR DESCRIPTION
For Doctrine 3 ArrayCollection are not allowed because it is not consider as an array. To avoid errors, we should consider to use an array