### PR TITLE
Add constructor on entities

### DIFF
--- a/src/Entity/Association.php
+++ b/src/Entity/Association.php
@@ -16,6 +16,14 @@ class Association
 
     private string $class;
 
+    public function __construct(string $type, ?string $table, ?string $label, int $fk, string $class): void{
+        $this->typ = $type;
+        $this->tbl = $table;
+        $this->label = $label;
+        $this->fk = $fk;
+        $this->class = $class;
+    }
+
     public function getId(): ?string
     {
         return $this->id;

--- a/src/Entity/Association.php
+++ b/src/Entity/Association.php
@@ -16,7 +16,7 @@ class Association
 
     private string $class;
 
-    public function __construct(string $type, ?string $table, ?string $label, int $fk, string $class): void{
+    public function __construct(string $type, ?string $table, ?string $label, int $fk, string $class){
         $this->typ = $type;
         $this->tbl = $table;
         $this->label = $label;

--- a/src/Entity/AuditLog.php
+++ b/src/Entity/AuditLog.php
@@ -20,6 +20,17 @@ class AuditLog
 
     private \DateTimeInterface $loggedAt;
 
+    public function __construct(string $action, string $table, ?Association $source=null, ?Association $target=null,  ?Association $blame=null, ?array $diff=[], ?\DateTimeInterface $date=null): void
+    {
+        $this->action = $action;
+        $this->tbl = $table;
+        $this->source = $source;
+        $this->target = $target;
+        $this->blame = $blame;
+        $this->diff = $diff;
+        $this->loggedAt = $date;
+    }
+
     public function getId(): ?string
     {
         return $this->id;

--- a/src/Entity/AuditLog.php
+++ b/src/Entity/AuditLog.php
@@ -20,7 +20,7 @@ class AuditLog
 
     private \DateTimeInterface $loggedAt;
 
-    public function __construct(string $action, string $table, ?Association $source=null, ?Association $target=null,  ?Association $blame=null, ?array $diff=[], ?\DateTimeInterface $date=null): void
+    public function __construct(string $action, string $table, ?Association $source=null, ?Association $target=null,  ?Association $blame=null, ?array $diff=[], ?\DateTimeInterface $date=null)
     {
         $this->action = $action;
         $this->tbl = $table;


### PR DESCRIPTION
Sometimes it's useful to be able to store custom actions in the change tracking database. Adding constructors to both entities is a good practice for doing this.