### PR TITLE
Add DoctrineBundle 3 compatibility for Symfony 7 stack

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "doctrine/dbal": "^3.2|^4.0",
-        "doctrine/doctrine-bundle": "^2.9",
+        "doctrine/doctrine-bundle": "^2.9|^3.0",
         "doctrine/orm": "^2.13|^3.0",
         "symfony/security-bundle": "^6.4 | ^7.0",
         "symfony/framework-bundle": "^6.4 | ^7.0",

--- a/tests/TestKernel.php
+++ b/tests/TestKernel.php
@@ -46,7 +46,7 @@ class TestKernel extends Kernel
             $container->loadFromExtension('doctrine', [
                 'dbal' => ['driver' => 'pdo_sqlite'],
                 'orm' => [
-                    'auto_generate_proxy_classes' => true,
+                    'auto_mapping' => false,
                     'mappings' => [
                         'DataDogAuditBundleFixtures' => [
                             'dir' => __DIR__.'/Entity',


### PR DESCRIPTION
Allow doctrine/doctrine-bundle ^3.0 in bundle constraints and update test kernel ORM config for DoctrineBundle 3 by replacing removed auto_generate_proxy_classes option.